### PR TITLE
Update spacetime-lang to 0.1.5 with field validation functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/styled": "^11.0.0",
     "@sentry/react": "^7.11.1",
     "@spacetimexyz/client": "^0.2.1-beta2",
-    "@spacetimexyz/lang": "^0.1.4",
+    "@spacetimexyz/lang": "0.1.5",
     "@spacetimexyz/react": "^0.2.1-beta2",
     "@stripe/react-stripe-js": "^1.10.0",
     "@stripe/stripe-js": "^1.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,6 +2663,11 @@
     "@ethersproject/strings" "^5.7.0"
     "@spacetimexyz/util" "^0.1.27"
 
+"@spacetimexyz/lang@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@spacetimexyz/lang/-/lang-0.1.5.tgz#535964319a7b5b58d9b83e3874b8648f55a7bc9e"
+  integrity sha512-v4IbclOBE03eONqYArdsiTIjc8UuMAtFIOIW2psnO31eVKy9+FfL0T85Z+Ck0hrrj0uLCsaTxn5MxU9QK3BmlA==
+
 "@spacetimexyz/lang@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@spacetimexyz/lang/-/lang-0.1.4.tgz#4ef6865afdf2932fa43ce094e5dece3790cdd68d"


### PR DESCRIPTION
We parse collections to get the fields, so we need to update spacetime-lang on any changes to the syntax, otherwise we would get errors on collections that use new syntax